### PR TITLE
Add window for help command

### DIFF
--- a/src/main/java/hokmah/command/MessageHandler.java
+++ b/src/main/java/hokmah/command/MessageHandler.java
@@ -124,40 +124,9 @@ public class MessageHandler {
      * @return
      */
     public String getHelpMessage() {
-        StringBuilder commandList = new StringBuilder();
-        commandList.append("You seriously need help? Fine. Here is what I can do:\n")
-                .append("list\n")
-                .append("\t(Shows all the tasks in the list)\n")
+        String message = "You seriously need help? Fine. I'll show you what I can do.";
 
-                .append("todo [name]\n")
-                .append("\t(Adds a todo task to the task list)\n")
-
-                .append("deadline [name] /by [" + DATE_TIME_FORMAT + "]\n")
-                .append("\t(Adds a deadline task to the task list)\n")
-
-                .append("event [name] /from [" + DATE_TIME_FORMAT + "] /to [" + DATE_TIME_FORMAT + "]\n")
-                .append("\t(Adds a event task to the task list)\n")
-
-                .append("mark [task number]\n")
-                .append("\t(Marks the task at [task number] in the task list as completed)\n")
-
-                .append("unmark [task number]\n")
-                .append("\t(Marks the task at [task number] in the task list as incomplete)\n")
-
-                .append("delete [task number]\n")
-                .append("\t(Deletes the task at [task number] in the task list)\n")
-
-                .append("upcoming /on [" + DATE_TIME_FORMAT + "]\n")
-                .append("\t(Shows all the tasks that are happening on the given date)\n")
-
-                .append("find [keyword]\n")
-                .append("\t(Finds tasks containing the specified keyword)\n")
-
-                .append("bye\n")
-                .append("\t(Only if you want to leave. It's not like I wanted you to be here.)");
-
-        return commandList.toString();
-
+        return message;
     }
 
     /**

--- a/src/main/java/hokmah/command/MessageHandler.java
+++ b/src/main/java/hokmah/command/MessageHandler.java
@@ -1,6 +1,5 @@
 package hokmah.command;
 
-import static hokmah.Hokmah.DATE_TIME_FORMAT;
 import static hokmah.Hokmah.LOGO;
 
 import java.time.LocalDateTime;

--- a/src/main/java/view/DialogBoxController.java
+++ b/src/main/java/view/DialogBoxController.java
@@ -17,15 +17,15 @@ import javafx.scene.layout.HBox;
  * Represents a dialog box consisting of an ImageView to represent the speaker's face
  * and a label containing text from the speaker.
  */
-public class DialogBox extends HBox {
+public class DialogBoxController extends HBox {
     @FXML
     private Label dialog;
     @FXML
     private ImageView displayPicture;
 
-    private DialogBox(String text) {
+    private DialogBoxController(String text) {
         try {
-            FXMLLoader fxmlLoader = new FXMLLoader(MainWindow.class.getResource("/view/DialogBox.fxml"));
+            FXMLLoader fxmlLoader = new FXMLLoader(MainWindowController.class.getResource("/view/DialogBox.fxml"));
             fxmlLoader.setController(this);
             fxmlLoader.setRoot(this);
             fxmlLoader.load();
@@ -47,12 +47,12 @@ public class DialogBox extends HBox {
         dialog.getStyleClass().add("reply-label");
     }
 
-    public static DialogBox getUserDialog(String text) {
-        return new DialogBox(text);
+    public static DialogBoxController getUserDialog(String text) {
+        return new DialogBoxController(text);
     }
 
-    public static DialogBox getDukeDialog(String text) {
-        var db = new DialogBox(text);
+    public static DialogBoxController getDukeDialog(String text) {
+        var db = new DialogBoxController(text);
         db.flip();
         return db;
     }

--- a/src/main/java/view/HelpWindowController.java
+++ b/src/main/java/view/HelpWindowController.java
@@ -1,0 +1,98 @@
+package view;
+
+
+import static hokmah.Hokmah.DATE_TIME_FORMAT;
+
+import java.io.IOException;
+
+import javafx.fxml.FXML;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.layout.AnchorPane;
+import javafx.scene.layout.GridPane;
+import javafx.scene.text.Text;
+import javafx.stage.Stage;
+
+
+/**
+ * Controller for the Help GUI.
+ */
+public class HelpWindowController extends AnchorPane {
+    @FXML
+    private Text helpLabel;
+
+    @FXML
+    private GridPane commandGrid;
+
+    @FXML
+    private Button exitButton;
+
+
+    private static boolean isShown = false;
+
+    public static boolean isShown() {
+        return isShown;
+    }
+
+
+    @FXML
+    public void initialize() {
+        helpLabel.setText("Here's what I can do. You better be grateful.");
+
+        String[][] helpTexts = {
+                {"list", "Shows all the tasks in the list"},
+                {"todo [name]", "Adds a todo task to the task list"},
+                {"deadline [name] /by [" + DATE_TIME_FORMAT + "]", "Adds a deadline task to the task list"},
+                {"event [name] /from [" + DATE_TIME_FORMAT + "] /to [" + DATE_TIME_FORMAT + "]", "Adds an event task to the task list"},
+                {"mark [task number]", "Marks the task at [task number] in the task list as completed"},
+                {"unmark [task number]", "Marks the task at [task number] in the task list as incomplete"},
+                {"delete [task number]", "Deletes the task at [task number] in the task list"},
+                {"upcoming /on [" + DATE_TIME_FORMAT + "]", "Shows all the tasks that are happening on the given date"},
+                {"find [keyword]", "Finds tasks containing the specified keyword"},
+                {"bye", "Only if you want to leave. It's not like I wanted you to be here."}
+        };
+
+        // Add the help text to the GridPane
+        for (int i = 0; i < helpTexts.length; i++) {
+
+            Label commandText = new Label(helpTexts[i][0]);
+            Label descriptionText = new Label(helpTexts[i][1]);
+
+            commandText.getStyleClass().add("text-table-row");
+            descriptionText.getStyleClass().add("text-table-row");
+
+            commandGrid.addRow(i + 1,
+                    commandText,
+                    descriptionText);
+        }
+    }
+
+    @FXML
+    private void handleExitButtonAction() {
+        Stage stage = (Stage) exitButton.getScene().getWindow();
+        isShown = false;
+        stage.close();
+
+    }
+
+    public static void showHelpWindow() {
+        try {
+            FXMLLoader fxmlLoader = new FXMLLoader(Main.class.getResource("/view/HelpWindow.fxml"));
+            AnchorPane helpWindow = fxmlLoader.load();
+            Stage helpStage = new Stage();
+
+            helpStage.setTitle("Help");
+            helpStage.setResizable(false);
+            helpStage.setScene(new Scene(helpWindow));
+
+            isShown = true;
+            helpStage.show();
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/src/main/java/view/HelpWindowController.java
+++ b/src/main/java/view/HelpWindowController.java
@@ -20,6 +20,8 @@ import javafx.stage.Stage;
  * Controller for the Help GUI.
  */
 public class HelpWindowController extends AnchorPane {
+    private static boolean isShown = false;
+
     @FXML
     private Text helpLabel;
 
@@ -30,13 +32,15 @@ public class HelpWindowController extends AnchorPane {
     private Button exitButton;
 
 
-    private static boolean isShown = false;
-
     public static boolean isShown() {
         return isShown;
     }
 
 
+    /**
+     * initializes the HelpWindow with respective help texts.
+     *
+     */
     @FXML
     public void initialize() {
         helpLabel.setText("Here's what I can do. You better be grateful.");
@@ -44,8 +48,11 @@ public class HelpWindowController extends AnchorPane {
         String[][] helpTexts = {
                 {"list", "Shows all the tasks in the list"},
                 {"todo [name]", "Adds a todo task to the task list"},
-                {"deadline [name] /by [" + DATE_TIME_FORMAT + "]", "Adds a deadline task to the task list"},
-                {"event [name] /from [" + DATE_TIME_FORMAT + "] /to [" + DATE_TIME_FORMAT + "]", "Adds an event task to the task list"},
+                {"deadline [name] /by ["
+                        + DATE_TIME_FORMAT + "]", "Adds a deadline task to the task list"},
+                {"event [name] /from ["
+                        + DATE_TIME_FORMAT + "] /to ["
+                        + DATE_TIME_FORMAT + "]", "Adds an event task to the task list"},
                 {"mark [task number]", "Marks the task at [task number] in the task list as completed"},
                 {"unmark [task number]", "Marks the task at [task number] in the task list as incomplete"},
                 {"delete [task number]", "Deletes the task at [task number] in the task list"},
@@ -69,6 +76,10 @@ public class HelpWindowController extends AnchorPane {
         }
     }
 
+    /**
+     * Closes the help window.
+     *
+     */
     @FXML
     private void handleExitButtonAction() {
         Stage stage = (Stage) exitButton.getScene().getWindow();
@@ -77,6 +88,11 @@ public class HelpWindowController extends AnchorPane {
 
     }
 
+    /**
+     * Shows the help window.
+     *
+     * @throws IOException if the fxml file for help window cannot be found.
+     */
     public static void showHelpWindow() {
         try {
             FXMLLoader fxmlLoader = new FXMLLoader(Main.class.getResource("/view/HelpWindow.fxml"));

--- a/src/main/java/view/Main.java
+++ b/src/main/java/view/Main.java
@@ -33,7 +33,7 @@ public class Main extends Application {
             assert stage.getMinHeight() == 220;
             assert stage.getMinWidth() == 900;
 
-            fxmlLoader.<MainWindow>getController().setHokmah(hokmah);
+            fxmlLoader.<MainWindowController>getController().setHokmah(hokmah);
 
             stage.show();
 

--- a/src/main/java/view/MainWindowController.java
+++ b/src/main/java/view/MainWindowController.java
@@ -17,7 +17,7 @@ import javafx.scene.layout.VBox;
 /**
  * Controller for the main GUI.
  */
-public class MainWindow extends AnchorPane {
+public class MainWindowController extends AnchorPane {
     @FXML
     private ScrollPane scrollPane;
     @FXML
@@ -28,6 +28,7 @@ public class MainWindow extends AnchorPane {
     private Button sendButton;
 
     private Hokmah hokmah;
+    private HelpWindowController helpWindowController;
 
     @FXML
     public void initialize() {
@@ -41,6 +42,10 @@ public class MainWindow extends AnchorPane {
         this.hokmah = h;
     }
 
+    public void setHelpWindowController(HelpWindowController h) {
+            this.helpWindowController = h;
+    }
+
     /**
      * Creates two dialog boxes, one echoing user input and the other containing Duke's reply and then appends them to
      * the dialog container. Clears the user input after processing.
@@ -50,8 +55,8 @@ public class MainWindow extends AnchorPane {
         String input = userInput.getText();
         String response = hokmah.getResponse(input);
         dialogContainer.getChildren().addAll(
-                DialogBox.getUserDialog(input),
-                DialogBox.getDukeDialog(response)
+                DialogBoxController.getUserDialog(input),
+                DialogBoxController.getDukeDialog(response)
         );
         userInput.clear();
 
@@ -62,7 +67,19 @@ public class MainWindow extends AnchorPane {
                     System.exit(0);
                 }
             }, 1000);
+        }
 
+        if(input.equals("help")) {
+            if (helpWindowController.isShown()) {
+                dialogContainer.getChildren().add(
+                        DialogBoxController.getDukeDialog("""
+                                Wait... You already have the help window open!
+                                Go look for it!""")
+                );
+                return;
+            }
+
+            helpWindowController.showHelpWindow();
         }
     }
 }

--- a/src/main/java/view/MainWindowController.java
+++ b/src/main/java/view/MainWindowController.java
@@ -43,7 +43,7 @@ public class MainWindowController extends AnchorPane {
     }
 
     public void setHelpWindowController(HelpWindowController h) {
-            this.helpWindowController = h;
+        this.helpWindowController = h;
     }
 
     /**
@@ -69,7 +69,7 @@ public class MainWindowController extends AnchorPane {
             }, 1000);
         }
 
-        if(input.equals("help")) {
+        if (input.equals("help")) {
             if (helpWindowController.isShown()) {
                 dialogContainer.getChildren().add(
                         DialogBoxController.getDukeDialog("""

--- a/src/main/resources/css/helpWindow.css
+++ b/src/main/resources/css/helpWindow.css
@@ -1,0 +1,42 @@
+/* General window styling */
+.root {
+    -fx-background-color: #f5f5f5;
+    -fx-padding: 10px;
+}
+
+
+.grid-pane {
+    -fx-border-color: black;
+    -fx-border-width: 1px;
+    -fx-padding: 5px;
+}
+
+/* Command Labels */
+.text-table-label {
+    -fx-font-weight: bold;
+    -fx-text-fill: #3c3c3c;
+    -fx-padding: 2px;
+}
+
+.label.text-table-row {
+    -fx-text-fill: #3c3c3c;
+    -fx-padding: 5px;
+}
+.text-label {
+    -fx-font-size: 20px;
+    -fx-text-fill: #444;
+}
+
+/* Exit Button Styling */
+.button {
+    -fx-background-color: #555555;
+    -fx-text-fill: white;
+    -fx-font-size: 14px;
+    -fx-padding: 8px 15px;
+    -fx-border-radius: 5px;
+    -fx-cursor: hand;
+}
+
+.button:hover {
+    -fx-background-color: #959595;
+}

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.text.Text?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.geometry.Insets?>
+
+<AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity"
+            stylesheets="@../css/helpWindow.css" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1"
+            fx:controller="view.HelpWindowController">
+
+    <VBox fx:id="helpContent" spacing="10"
+          AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+        <Text fx:id="helpLabel" styleClass="text-label" textAlignment="JUSTIFY"/>
+
+        <GridPane fx:id="commandGrid" gridLinesVisible="true" hgap="0" vgap="0">
+            <padding>
+                <Insets top="10" right="0" bottom="10" left="0"/>
+            </padding>
+
+            <children>
+                <Label text="Command" styleClass="text-table-label"/>
+                <Label text="Description" styleClass="text-table-label" GridPane.columnIndex="1"/>
+            </children>
+        </GridPane>
+
+        <HBox alignment="CENTER_RIGHT">
+            <Button fx:id="exitButton" text="Exit" onAction="#handleExitButtonAction"/>
+        </HBox>
+    </VBox>
+</AnchorPane>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -6,7 +6,7 @@
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.VBox?>
 
-<AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="600.0" prefWidth="400.0" stylesheets="@../css/main.css" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:controller="view.MainWindow">
+<AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="600.0" prefWidth="400.0" stylesheets="@../css/main.css" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:controller="view.MainWindowController">
     <children>
         <TextField fx:id="userInput" layoutY="558.0" onAction="#handleUserInput" prefHeight="41.0" prefWidth="324.0" AnchorPane.bottomAnchor="1.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="76.0" />
         <Button fx:id="sendButton" layoutX="324.0" layoutY="558.0" mnemonicParsing="false" onAction="#handleUserInput" prefHeight="41.0" prefWidth="100.0" text="SEND" textAlignment="CENTER" AnchorPane.bottomAnchor="1.0" AnchorPane.rightAnchor="0.0" />


### PR DESCRIPTION
Help command had no window before to show all of the commands leading to less readable UI.

Using JavaFX with CSS to create a new window for the help command increases the readability of the list of the commands while allowing the window of list of commands to be kept to the side for reference.

Let's
- Remove the old list of commands in the `MessageHandler.java` and transform it into a table in the help window
- Rename the window Java files into Handlers to handle the windows
- Create a new help window with respective CSS, FXML, and Java files